### PR TITLE
build: build: use @v1 of shared workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ permissions:
 
 jobs:
   ci:
-    uses: nitrado/hytale-plugin-workflows/.github/workflows/plugin-ci.yml@main
+    uses: nitrado/hytale-plugin-workflows/.github/workflows/plugin-ci.yml@v1
     secrets: inherit
     # Optional: override defaults
     # with:


### PR DESCRIPTION
Use newly created @v1 tag of the shared workflow repository