### PR TITLE
fix: replace CommandSender.getDisplayName()

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
 
     <properties>
         <revision>1.0.0-SNAPSHOT</revision>
-        <hytale.server.version>2026.01.24-6e2d4fc36</hytale.server.version>
+        <hytale.server.version>0.5.6</hytale.server.version>
         <maven.compiler.source>25</maven.compiler.source>
         <maven.compiler.target>25</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/src/main/java/net/nitrado/hytale/plugins/webserver/commands/CodeCreateCommand.java
+++ b/src/main/java/net/nitrado/hytale/plugins/webserver/commands/CodeCreateCommand.java
@@ -33,7 +33,7 @@ public class CodeCreateCommand extends AbstractCommand {
             return CompletableFuture.completedFuture(null);
         }
 
-        var code = this.loginCodeStore.createCode(context.sender().getUuid(), context.sender().getDisplayName());
+        var code = this.loginCodeStore.createCode(context.sender().getUuid(), context.sender().getUsername());
 
         context.sendMessage(Message.raw("Your web server login code is: " + code));
         context.sendMessage(Message.raw("Do not share this code with anybody."));


### PR DESCRIPTION
This PR fixes the build against the current server version by replacing the removed CommandSender.getDisplayName() with CommandSender.getUsername()

Closes #25 